### PR TITLE
Fix Containerd default config file creation

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -62,7 +62,7 @@ $ sudo apt-get upgrade -y
 $ sudo apt-get install containerd -y
 $ sudo mkdir -p /etc/containerd
 $ sudo su -
-$ containerd config default  /etc/containerd/config.toml
+$ containerd config default >> /etc/containerd/config.toml
 $ exit
 $ sudo systemctl restart containerd
 ```


### PR DESCRIPTION
Containerd default config'i oluşturan komutta ufak bir hata var: `>` veya `>>` eksik gibi duruyor. Bu yüzden config'i sadece ekrana çıktı olarak yazıyor, dosyayı oluşturmuyor.